### PR TITLE
Limit and Offset for pagination

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -44,6 +44,13 @@ type App struct {
 	Server            *http.Server
 	Cache             *cache.Cache
 	OffersCacheMaxAge time.Duration
+	Pagination        *Pagination
+}
+
+//Pagination holds the page size (limit) and the offset that is the page number
+type Pagination struct {
+	Limit  uint64
+	Offset uint64
 }
 
 //NewApp ctor
@@ -214,9 +221,19 @@ func (a *App) configureApp() error {
 	a.configureSentry()
 
 	a.MaxAge = a.Config.GetInt64("cache.maxAgeSeconds")
+	a.configurePagination()
 	a.configureServer()
 	a.configureCache()
 	return nil
+}
+
+func (a *App) configurePagination() {
+	limit := uint64(a.Config.GetInt64("pagination.limit"))
+	offset := uint64(a.Config.GetInt64("pagination.offset"))
+	a.Pagination = &Pagination{
+		Limit:  limit,
+		Offset: offset,
+	}
 }
 
 func (a *App) configureCache() {

--- a/api/offer.go
+++ b/api/offer.go
@@ -185,20 +185,27 @@ func (g *OfferHandler) list(w http.ResponseWriter, r *http.Request) {
 
 	var limit uint64
 	if limitStr == "" {
-		limit = 50
-	} else if limit, err = strconv.ParseUint(limitStr, 10, 64); err != nil {
-		logger.WithError(err).Error("List game offers failed.")
-		g.App.HandleError(w, http.StatusBadRequest, "The limit parameter must be an uint.", err)
-		return
+		limit = g.App.Pagination.Limit
+	} else {
+		var err error
+		limit, err = strconv.ParseUint(limitStr, 10, 64)
+		if err != nil {
+			logger.WithError(err).Error("List game offers failed.")
+			g.App.HandleError(w, http.StatusBadRequest, "The limit parameter must be an uint.", err)
+			return
+		}
 	}
 
 	var offset uint64
 	if offsetStr == "" {
-		offset = 0
-	} else if offset, err = strconv.ParseUint(offsetStr, 10, 64); err != nil {
-		logger.WithError(err).Error("List game offers failed.")
-		g.App.HandleError(w, http.StatusBadRequest, "The offset parameter must be an uint.", err)
-		return
+		offset = g.App.Pagination.Offset
+	} else {
+		offset, err = strconv.ParseUint(offsetStr, 10, 64)
+		if err != nil {
+			logger.WithError(err).Error("List game offers failed.")
+			g.App.HandleError(w, http.StatusBadRequest, "The offset parameter must be an uint.", err)
+			return
+		}
 	}
 
 	var offers []*models.Offer
@@ -221,10 +228,5 @@ func (g *OfferHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bts, _ := json.Marshal(responseObj)
-	status := http.StatusOK
-	if len(offers) == 0 {
-		status = http.StatusNoContent
-	}
-
-	WriteBytes(w, status, bts)
+	WriteBytes(w, http.StatusOK, bts)
 }

--- a/api/offer.go
+++ b/api/offer.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/topfreegames/offers/errors"
@@ -160,7 +161,12 @@ func (g *OfferHandler) updateOffer(w http.ResponseWriter, r *http.Request) {
 
 func (g *OfferHandler) list(w http.ResponseWriter, r *http.Request) {
 	mr := metricsReporterFromCtx(r.Context())
-	gameID := r.URL.Query().Get("game-id")
+
+	vars := r.URL.Query()
+	gameID := vars.Get("game-id")
+	limitStr := vars.Get("limit")
+	offsetStr := vars.Get("offset")
+	var err error
 	userEmail := userEmailFromContext(r.Context())
 
 	logger := g.App.Logger.WithFields(logrus.Fields{
@@ -177,10 +183,28 @@ func (g *OfferHandler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var err error
+	var limit uint64
+	if limitStr == "" {
+		limit = 50
+	} else if limit, err = strconv.ParseUint(limitStr, 10, 64); err != nil {
+		logger.WithError(err).Error("List game offers failed.")
+		g.App.HandleError(w, http.StatusBadRequest, "The limit parameter must be an uint.", err)
+		return
+	}
+
+	var offset uint64
+	if offsetStr == "" {
+		offset = 0
+	} else if offset, err = strconv.ParseUint(offsetStr, 10, 64); err != nil {
+		logger.WithError(err).Error("List game offers failed.")
+		g.App.HandleError(w, http.StatusBadRequest, "The offset parameter must be an uint.", err)
+		return
+	}
+
 	var offers []*models.Offer
+	var pages int
 	err = mr.WithSegment(models.SegmentModel, func() error {
-		offers, err = models.ListOffers(g.App.DB, gameID, mr)
+		offers, pages, err = models.ListOffers(g.App.DB, gameID, limit, offset, mr)
 		return err
 	})
 
@@ -191,10 +215,16 @@ func (g *OfferHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Info("Listed game offers successfully.")
-	if len(offers) == 0 {
-		Write(w, http.StatusOK, "[]")
-		return
+	responseObj := map[string]interface{}{
+		"offers": offers,
+		"pages":  pages,
 	}
-	bytes, _ := json.Marshal(offers)
-	WriteBytes(w, http.StatusOK, bytes)
+
+	bts, _ := json.Marshal(responseObj)
+	status := http.StatusOK
+	if len(offers) == 0 {
+		status = http.StatusNoContent
+	}
+
+	WriteBytes(w, status, bts)
 }

--- a/api/offer_test.go
+++ b/api/offer_test.go
@@ -1046,23 +1046,177 @@ var _ = Describe("Offer Template Handler", func() {
 			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
 
 			Expect(recorder.Code).To(Equal(http.StatusOK))
-			var obj []map[string]interface{}
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(5))
+			for i := 0; i < len(obj); i++ {
+				offer := offers[i].(map[string]interface{})
+				Expect(offer).To(HaveKey("id"))
+				Expect(offer).To(HaveKey("name"))
+				Expect(offer).To(HaveKey("productId"))
+				Expect(offer).To(HaveKey("gameId"))
+				Expect(offer).To(HaveKey("contents"))
+				Expect(offer).To(HaveKey("metadata"))
+				Expect(offer).To(HaveKey("enabled"))
+				Expect(offer).To(HaveKey("placement"))
+				Expect(offer).To(HaveKey("period"))
+				Expect(offer).To(HaveKey("frequency"))
+				Expect(offer).To(HaveKey("trigger"))
+			}
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(1)))
+		})
+
+		It("should return two offers with limit 2 and no offset", func() {
+			limit := 2
+			url := fmt.Sprintf("/offers?game-id=offers-game&limit=%d", limit)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(2))
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(3)))
+		})
+
+		It("should return no offers if limit is 0", func() {
+			limit := 0
+			url := fmt.Sprintf("/offers?game-id=offers-game&limit=%d", limit)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(0))
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(0)))
+		})
+
+		It("should return three offers with no limit and offset 2", func() {
+			offset := 2
+			url := fmt.Sprintf("/offers?game-id=offers-game&offset=%d", offset)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(3))
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(1)))
+		})
+
+		It("should return three offers with no limit and offset 2", func() {
+			offset := 2
+			url := fmt.Sprintf("/offers?game-id=offers-game&offset=%d", offset)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(3))
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(1)))
+		})
+
+		It("should return error if limit is negative", func() {
+			limit := -1
+			url := fmt.Sprintf("/offers?game-id=offers-game&limit=%d", limit)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj["code"]).To(Equal("OFF-004"))
+			Expect(obj["error"]).To(Equal("The limit parameter must be an uint."))
+			Expect(obj["description"]).To(Equal("strconv.ParseUint: parsing \"-1\": invalid syntax"))
+		})
+
+		It("should return error if limit is not a number", func() {
+			limit := "qwerty"
+			url := fmt.Sprintf("/offers?game-id=offers-game&limit=%s", limit)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+			var obj map[string]interface{}
 			err := json.Unmarshal([]byte(recorder.Body.String()), &obj)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(obj).To(HaveLen(5))
-			for i := 0; i < len(obj); i++ {
-				Expect(obj[i]).To(HaveKey("id"))
-				Expect(obj[i]).To(HaveKey("name"))
-				Expect(obj[i]).To(HaveKey("productId"))
-				Expect(obj[i]).To(HaveKey("gameId"))
-				Expect(obj[i]).To(HaveKey("contents"))
-				Expect(obj[i]).To(HaveKey("metadata"))
-				Expect(obj[i]).To(HaveKey("enabled"))
-				Expect(obj[i]).To(HaveKey("placement"))
-				Expect(obj[i]).To(HaveKey("period"))
-				Expect(obj[i]).To(HaveKey("frequency"))
-				Expect(obj[i]).To(HaveKey("trigger"))
-			}
+			Expect(obj["code"]).To(Equal("OFF-004"))
+			Expect(obj["error"]).To(Equal("The limit parameter must be an uint."))
+			Expect(obj["description"]).To(Equal("strconv.ParseUint: parsing \"qwerty\": invalid syntax"))
+		})
+
+		It("should return error if offset is negative", func() {
+			offset := -1
+			url := fmt.Sprintf("/offers?game-id=offers-game&offset=%d", offset)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+			var obj map[string]interface{}
+			err := json.Unmarshal([]byte(recorder.Body.String()), &obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj["code"]).To(Equal("OFF-004"))
+			Expect(obj["error"]).To(Equal("The offset parameter must be an uint."))
+			Expect(obj["description"]).To(Equal("strconv.ParseUint: parsing \"-1\": invalid syntax"))
+		})
+
+		It("should return error if offset is not a number", func() {
+			offset := "qwerty"
+			url := fmt.Sprintf("/offers?game-id=offers-game&offset=%s", offset)
+			request, _ := http.NewRequest("GET", url, nil)
+
+			app.Router.ServeHTTP(recorder, request)
+			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
+
+			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
+			var obj map[string]interface{}
+			err := json.Unmarshal([]byte(recorder.Body.String()), &obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj["code"]).To(Equal("OFF-004"))
+			Expect(obj["error"]).To(Equal("The offset parameter must be an uint."))
+			Expect(obj["description"]).To(Equal("strconv.ParseUint: parsing \"qwerty\": invalid syntax"))
 		})
 
 		It("should return empty list if no offers", func() {
@@ -1070,8 +1224,17 @@ var _ = Describe("Offer Template Handler", func() {
 
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
-			Expect(recorder.Code).To(Equal(http.StatusOK))
-			Expect(recorder.Body.String()).To(Equal("[]"))
+			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+
+			var obj map[string]interface{}
+			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			offers := obj["offers"].([]interface{})
+			Expect(offers).To(HaveLen(0))
+
+			pages := obj["pages"].(float64)
+			Expect(pages).To(Equal(float64(0)))
 		})
 
 		It("should return status code of 400 if game-id is not provided", func() {

--- a/api/offer_test.go
+++ b/api/offer_test.go
@@ -1099,7 +1099,7 @@ var _ = Describe("Offer Template Handler", func() {
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
 
-			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+			Expect(recorder.Code).To(Equal(http.StatusOK))
 			var obj map[string]interface{}
 			err := json.Unmarshal(recorder.Body.Bytes(), &obj)
 			Expect(err).NotTo(HaveOccurred())
@@ -1224,7 +1224,7 @@ var _ = Describe("Offer Template Handler", func() {
 
 			app.Router.ServeHTTP(recorder, request)
 			Expect(recorder.Header().Get("Content-Type")).To(Equal("application/json"))
-			Expect(recorder.Code).To(Equal(http.StatusNoContent))
+			Expect(recorder.Code).To(Equal(http.StatusOK))
 
 			var obj map[string]interface{}
 			err := json.Unmarshal(recorder.Body.Bytes(), &obj)

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -23,3 +23,6 @@ offersCache:
 basicauth:
   username: user
   password: pass
+pagination:
+  limit: 50
+  offset: 0

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -20,3 +20,6 @@ cache:
 offersCache:
   maxAgeSeconds: 300
   cleanupInterval: 30
+pagination:
+  limit: 50
+  offset: 0

--- a/docs/source/API.md
+++ b/docs/source/API.md
@@ -397,7 +397,10 @@ Offers API
       ```
 
   ### List Offers
-  `GET /offers?game-id=<required-game-id>`
+  `GET /offers?game-id=<required-game-id>&limit=<optional-limit>&offset=<optional-offset>`
+  * game-id: the given game id.
+  * limit: how many offers will be returned (the page size); default is 50.
+  * offset: the page number; default is 0.
 
   Lists all game's offers.
 
@@ -408,34 +411,38 @@ Offers API
     * Content:
 
     ```
-    [    
-      {
-        "id":        [uuidv4],   // offer template unique identifier
-        "key":       [uuidv4],
-        "name":      [string],
-        "productId": [string],
-        "gameId":    [string],
-        "contents":  [json],  
-        "metadata":  [json],  
-        "placement": [string],
-        "period":    {        
-          "every": [string],  
-          "max":   [int]      
-        },   
-        "frequency": {        
-          "every": [string],  
-          "max":   [int]      
-        },   
-        "trigger":   {        
-          "from":  [int],     
-          "to":    [int]      
+    {
+      "offers": [    
+        {
+          "id":        [uuidv4],   // offer template unique identifier
+          "key":       [uuidv4],
+          "name":      [string],
+          "productId": [string],
+          "gameId":    [string],
+          "contents":  [json],  
+          "metadata":  [json],  
+          "placement": [string],
+          "period":    {        
+            "every": [string],  
+            "max":   [int]      
+          },   
+          "frequency": {        
+            "every": [string],  
+            "max":   [int]      
+          },   
+          "trigger":   {        
+            "from":  [int],     
+            "to":    [int]      
+          },
+          "enabled":   [bool],
+          "version":   [int],
+          "filters":   [json]
         },
-        "enabled":   [bool],
-        "version":   [int],
-        "filters":   [json]
-      },
-      ...
-    ]
+        ...
+      ],
+      "pages": [int]
+    }
+    
     ```
 
   * Error response


### PR DESCRIPTION
## Pagination

Pagination on GET /offers

 - On GET /offers, use parameters _limit_ to tell the page size, and _offset_ to tell which page to return. 
- If limit is not informed, the default is 50
- If offset is not informed, the default is 0
- The GET /offers response now is a JSON with the following keys:
  - offers: list of offers
  - page: total number of pages given the limit